### PR TITLE
redesign: Nightpress editorial homepage

### DIFF
--- a/src/homepage/components/Hero.tsx
+++ b/src/homepage/components/Hero.tsx
@@ -3,29 +3,79 @@ const BASE_URL = '__BASE_URL__';
 export function Hero() {
   return (
     <section className="hero">
-      <div className="hero-eyebrow">
-        <span className="hero-dot" aria-hidden="true" />
-        <span>Live on Cloudflare Workers</span>
+      <div className="hero-content">
+        <div className="hero-eyebrow">
+          <span className="hero-dot" aria-hidden="true" />
+          <span>Live on Cloudflare Workers</span>
+        </div>
+        <h1>
+          Manage <a href="https://ticktick.com">TickTick</a><br />
+          with <em>any MCP client</em>
+        </h1>
+        <p className="hero-sub">
+          A remote, multi-user MCP server for TickTick. OAuth is handled automatically &mdash; connect with a single endpoint.
+        </p>
+        <p className="hero-sub">
+          Designed for practical daily use, tickmcp keeps setup compact while exposing the project and task operations teams
+          actually need.
+        </p>
+        <div className="endpoint" role="status" aria-label="MCP endpoint URL">
+          <span className="endpoint-badge" aria-hidden="true">POST</span>
+          <code>{BASE_URL}/mcp</code>
+        </div>
+        <p className="hero-meta">
+          Maintained by <a href="https://maheshrijal.com/">Mahesh Rijal</a>
+        </p>
       </div>
-      <h1>
-        Manage <a href="https://ticktick.com">TickTick</a><br />
-        with <em>any MCP client</em>
-      </h1>
-      <p className="hero-sub">
-        A remote, multi-user MCP server for TickTick. OAuth is handled automatically &mdash; connect with a single endpoint.
-      </p>
-      <p className="hero-sub">
-        Designed for practical daily use, tickmcp keeps setup compact while exposing the project and task operations teams
-        actually need. The service is built for reliability under real workload patterns, not demo traffic, so client
-        integrations remain stable across repeated task fetches, updates, and completions.
-      </p>
-      <div className="endpoint" role="status" aria-label="MCP endpoint URL">
-        <span className="endpoint-badge" aria-hidden="true">POST</span>
-        <code>{BASE_URL}/mcp</code>
+
+      <div className="hero-terminal-wrap" aria-hidden="true">
+        <div className="terminal">
+          <div className="terminal-bar">
+            <span className="terminal-btn terminal-btn-r" />
+            <span className="terminal-btn terminal-btn-y" />
+            <span className="terminal-btn terminal-btn-g" />
+            <span className="terminal-label">tickmcp · MCP Session</span>
+          </div>
+          <div className="terminal-body">
+            <div className="terminal-line">
+              <span className="terminal-prompt">$</span>
+              <span className="terminal-cmd"> claude mcp add tickmcp \</span>
+            </div>
+            <div className="terminal-line">
+              <span className="terminal-dim">{'    '}--transport http \</span>
+            </div>
+            <div className="terminal-line">
+              <span className="terminal-dim">{'    '}tickmcp.mrjl.dev/mcp</span>
+            </div>
+            <span className="terminal-blank" />
+            <div className="terminal-line"><span className="terminal-success">✓</span><span className="terminal-cmd"> OAuth authorized</span></div>
+            <div className="terminal-line"><span className="terminal-success">✓</span><span className="terminal-cmd"> 14 tools registered</span></div>
+            <span className="terminal-blank" />
+            <div className="terminal-line">
+              <span className="terminal-prompt">{'>'}</span>
+              <span className="terminal-cmd">{' list_tasks({ dueFilter: "today" })'}</span>
+            </div>
+            <span className="terminal-blank" />
+            <div className="terminal-task">
+              <span className="terminal-task-dot-active">◉</span>
+              <span className="terminal-task-title">Review Q1 goals</span>
+              <span className="terminal-priority-high">↑ HIGH</span>
+            </div>
+            <div className="terminal-task">
+              <span className="terminal-task-dot-active">◉</span>
+              <span className="terminal-task-title">Send standup notes</span>
+              <span className="terminal-priority-med">MED</span>
+            </div>
+            <div className="terminal-task">
+              <span className="terminal-task-dot-open">○</span>
+              <span className="terminal-task-title">Plan sprint board</span>
+              <span className="terminal-priority-med">MED</span>
+            </div>
+            <hr className="terminal-divider" />
+            <div className="terminal-line terminal-count">3 tasks due today<span className="terminal-cursor" /></div>
+          </div>
+        </div>
       </div>
-      <p className="hero-meta">
-        Maintained by <a href="https://maheshrijal.com/">Mahesh Rijal</a>
-      </p>
     </section>
   );
 }

--- a/src/homepage/components/QuickOnboarding.tsx
+++ b/src/homepage/components/QuickOnboarding.tsx
@@ -1,10 +1,26 @@
 import { CodeBlock } from './CodeBlock';
 
 const BASE_URL = '__BASE_URL__';
-const ONBOARDING_ITEMS = [
-  { name: 'Codex', snippet: `codex mcp add tickmcp --url ${BASE_URL}/mcp` },
-  { name: 'Claude Code', snippet: `claude mcp add tickmcp --transport http ${BASE_URL}/mcp` },
+
+type OnboardingItem = {
+  step: string;
+  name: string;
+  snippet: string;
+};
+
+const ONBOARDING_ITEMS: OnboardingItem[] = [
   {
+    step: '01',
+    name: 'Codex',
+    snippet: `codex mcp add tickmcp --url ${BASE_URL}/mcp`,
+  },
+  {
+    step: '02',
+    name: 'Claude Code',
+    snippet: `claude mcp add tickmcp --transport http ${BASE_URL}/mcp`,
+  },
+  {
+    step: '03',
     name: 'Claude Desktop / Cursor',
     snippet: `{
   "mcpServers": {
@@ -25,6 +41,7 @@ export function QuickOnboarding() {
         {ONBOARDING_ITEMS.map((item) => (
           <div key={item.name} className="setup-item">
             <div className="setup-header">
+              <span className="setup-step">{item.step}</span>
               <span className="setup-name">{item.name}</span>
             </div>
             <CodeBlock>{item.snippet}</CodeBlock>
@@ -33,6 +50,7 @@ export function QuickOnboarding() {
 
         <div className="setup-item">
           <div className="setup-header">
+            <span className="setup-step">04</span>
             <span className="setup-name">ChatGPT / Claude</span>
           </div>
           <p className="setup-desc">Add as a remote MCP server with this URL:</p>

--- a/src/homepage/components/SupportedTools.tsx
+++ b/src/homepage/components/SupportedTools.tsx
@@ -15,10 +15,10 @@ const PROJECT_TOOLS: ToolItem[] = [
 ];
 
 const TASK_TOOLS: ToolItem[] = [
-  { label: 'ticktick_list_tasks(status=0 only)', tone: 'green' },
+  { label: 'ticktick_list_tasks()', tone: 'green' },
   { label: 'ticktick_get_task()', tone: 'green' },
-  { label: 'ticktick_create_task(repeat?/repeatFlag?, items?)', tone: 'blue' },
-  { label: 'ticktick_update_task(repeat?/repeatFlag?, items?)', tone: 'blue' },
+  { label: 'ticktick_create_task()', tone: 'blue' },
+  { label: 'ticktick_update_task()', tone: 'blue' },
   { label: 'ticktick_patch_task_items()', tone: 'blue' },
   { label: 'ticktick_complete_task()', tone: 'orange' },
   { label: 'ticktick_delete_task()', tone: 'orange' },
@@ -51,7 +51,7 @@ export function SupportedTools() {
   return (
     <section className="page-section" id="api-surface">
       <h2 className="section-label">API Surface</h2>
-      <p className="setup-desc">Completed-task listing is intentionally unsupported in <code>ticktick_list_tasks</code>; use active filters with <code>status=0</code>.</p>
+      <p className="setup-desc">Active tasks only — completed-task listing is intentionally unsupported.</p>
 
       <div className="tools-columns">
         <div>

--- a/src/homepage/styles.ts
+++ b/src/homepage/styles.ts
@@ -1,32 +1,36 @@
 /**
  * TickMCP homepage CSS.
- * Warm industrial editorial layout.
+ * Nightpress — warm editorial dark with golden-sunrise h1 gradient.
+ * Dark mode: bright lemon-gold → vivid orange (sunrise).
+ * Light mode: deep rust → deep ocean (clearly distinct on parchment).
  */
 export const homepageStyles = `
 *{box-sizing:border-box;margin:0;padding:0}
 
 :root{
-  --bg:#111214;
-  --surface:#1a1d21;
-  --surface-2:#252a30;
-  --surface-3:#3a424d;
-  --ink:#f7f3e8;
-  --ink-2:#d5ccbb;
-  --ink-3:#a79e8e;
-  --ink-4:#7e786c;
-  --border:#2f353e;
-  --border-2:#475362;
-  --accent:#f0b44d;
-  --accent-dim:#d18e1f;
-  --accent-glow:rgba(240,180,77,.14);
-  --green:#56d481;
-  --green-dim:rgba(86,212,129,.16);
-  --blue:#6ecdf4;
-  --blue-dim:rgba(110,205,244,.16);
-  --orange:#ff9f53;
-  --orange-dim:rgba(255,159,83,.15);
-  --code-bg:#0d1014;
-  --radius:10px;
+  --bg:#0d0c08;
+  --surface:#181610;
+  --surface-2:#211f14;
+  --surface-3:#2e2b1c;
+  --ink:#f0ead8;
+  --ink-2:#c8bfa8;
+  --ink-3:#86806e;
+  --ink-4:#5e5a4e;
+  --border:#252210;
+  --border-2:#403c28;
+  --accent:#f5c032;
+  --accent-dim:#d4a020;
+  --accent-glow:rgba(245,192,50,.15);
+  --h1-start:#fde68a;
+  --h1-end:#fb923c;
+  --green:#4ade80;
+  --green-dim:rgba(74,222,128,.13);
+  --blue:#7dd3fc;
+  --blue-dim:rgba(125,211,252,.13);
+  --orange:#f87171;
+  --orange-dim:rgba(248,113,113,.13);
+  --code-bg:#080805;
+  --radius:8px;
   --mono:"IBM Plex Mono","SF Mono",Menlo,Consolas,monospace;
   --sans:"Avenir Next","Segoe UI",Helvetica,sans-serif;
   --display:"Iowan Old Style","Palatino Linotype","Book Antiqua",Palatino,serif;
@@ -34,26 +38,28 @@ export const homepageStyles = `
 
 @media(prefers-color-scheme:light){
   :root{
-    --bg:#f8f6ef;
-    --surface:#efeadf;
-    --surface-2:#e4ddcd;
-    --surface-3:#d2c8b3;
-    --ink:#1f2125;
-    --ink-2:#3b4048;
-    --ink-3:#59606b;
-    --ink-4:#777f8d;
-    --border:#dbd1bf;
-    --border-2:#beb098;
-    --accent:#9c5718;
-    --accent-dim:#b86b23;
-    --accent-glow:rgba(156,87,24,.1);
-    --green:#1d8a4d;
-    --green-dim:rgba(29,138,77,.1);
-    --blue:#1f88b5;
-    --blue-dim:rgba(31,136,181,.1);
-    --orange:#c7681a;
-    --orange-dim:rgba(199,104,26,.1);
-    --code-bg:#f2ede1;
+    --bg:#f9f5ec;
+    --surface:#eeeadf;
+    --surface-2:#e4dece;
+    --surface-3:#d6cebc;
+    --ink:#1a1710;
+    --ink-2:#3b3620;
+    --ink-3:#625c46;
+    --ink-4:#888060;
+    --border:#ddd7c6;
+    --border-2:#bfb89a;
+    --accent:#9c4a00;
+    --accent-dim:#b85800;
+    --accent-glow:rgba(156,74,0,.1);
+    --h1-start:#92400e;
+    --h1-end:#0c4a6e;
+    --green:#15803d;
+    --green-dim:rgba(21,128,61,.1);
+    --blue:#1d4ed8;
+    --blue-dim:rgba(29,78,216,.1);
+    --orange:#b91c1c;
+    --orange-dim:rgba(185,28,28,.1);
+    --code-bg:#ede8da;
   }
 }
 
@@ -70,10 +76,22 @@ body{
   -webkit-tap-highlight-color:transparent;
   overflow-x:hidden;
   background-image:
-    radial-gradient(circle at 14% -8%,color-mix(in srgb,var(--accent) 18%,transparent),transparent 32%),
-    radial-gradient(circle at 86% 0%,color-mix(in srgb,var(--blue) 16%,transparent),transparent 30%);
+    radial-gradient(ellipse 70% 50% at -5% 0%,color-mix(in srgb,var(--h1-start) 12%,transparent),transparent 55%),
+    radial-gradient(ellipse 50% 40% at 105% 5%,color-mix(in srgb,var(--h1-end) 10%,transparent),transparent 50%);
 }
 
+/* Grain overlay */
+body::after{
+  content:'';
+  position:fixed;
+  inset:0;
+  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='300' height='300'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='300' height='300' filter='url(%23n)' opacity='1'/%3E%3C/svg%3E");
+  opacity:.03;
+  pointer-events:none;
+  z-index:9999;
+}
+
+/* Skip link */
 .skip{
   position:absolute;left:-9999px;top:auto;
   width:1px;height:1px;overflow:hidden;
@@ -85,13 +103,15 @@ body{
   color:var(--accent);font-size:.8rem;
 }
 
+/* NAV */
 nav{
   position:sticky;top:0;z-index:50;
   display:flex;align-items:center;justify-content:space-between;
-  padding:.75rem 2rem;
-  background:color-mix(in srgb,var(--bg) 85%,transparent);
-  backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);
+  padding:.7rem 2rem;
+  background:color-mix(in srgb,var(--bg) 82%,transparent);
+  backdrop-filter:blur(14px);-webkit-backdrop-filter:blur(14px);
   border-bottom:1px solid var(--border);
+  box-shadow:0 1px 0 0 color-mix(in srgb,var(--accent) 8%,transparent);
 }
 .nav-brand{
   display:flex;align-items:center;gap:.5rem;
@@ -99,32 +119,40 @@ nav{
   color:var(--ink);text-decoration:none;letter-spacing:-.01em;
 }
 .nav-mark{
-  width:24px;height:24px;border-radius:6px;
-  background:linear-gradient(135deg,var(--accent),var(--orange));
+  width:22px;height:22px;border-radius:5px;
+  background:linear-gradient(135deg,var(--h1-start),var(--h1-end));
   display:grid;place-items:center;flex-shrink:0;
+  box-shadow:0 0 12px var(--accent-glow);
 }
-.nav-mark svg{width:14px;height:14px}
+.nav-mark svg{width:13px;height:13px}
 .nav-links{display:flex;align-items:center;gap:1.25rem}
 .nav-links a{
-  font-size:.8rem;color:var(--ink-3);text-decoration:none;
-  transition:color .15s;
+  font-size:.78rem;color:var(--ink-3);text-decoration:none;
+  transition:color .15s;letter-spacing:.01em;
 }
 .nav-links a:hover{color:var(--ink)}
 .nav-links a:focus-visible{outline:2px solid var(--accent);outline-offset:2px;border-radius:3px}
 
+/* HERO — split layout */
 .hero{
-  padding:5rem 2rem 4rem;
-  max-width:820px;
+  padding:5.5rem 2rem 4rem;
+  max-width:1060px;
   margin:0 auto;
-  text-align:center;
+  display:flex;
+  align-items:center;
+  gap:3.5rem;
+}
+.hero-content{
+  flex:1;
+  min-width:0;
 }
 .hero-eyebrow{
   display:inline-flex;align-items:center;gap:.4rem;
-  padding:.3rem .8rem;border-radius:999px;
+  padding:.3rem .75rem;border-radius:999px;
   border:1px solid var(--border);background:var(--surface);
-  font-size:.7rem;font-weight:600;color:var(--ink-2);
-  letter-spacing:.04em;text-transform:uppercase;
-  margin-bottom:1.5rem;
+  font-size:.67rem;font-weight:700;color:var(--ink-2);
+  letter-spacing:.06em;text-transform:uppercase;
+  margin-bottom:1.75rem;
 }
 .hero-dot{
   width:5px;height:5px;border-radius:50%;
@@ -132,117 +160,216 @@ nav{
   box-shadow:0 0 8px var(--green);
   animation:blink 2.5s ease-in-out infinite;
 }
-@keyframes blink{0%,100%{opacity:1}50%{opacity:.3}}
+@keyframes blink{0%,100%{opacity:1}50%{opacity:.25}}
 
 h1{
   font-family:var(--display);
-  font-size:clamp(2.5rem,6vw,4.1rem);
+  font-size:clamp(2.75rem,6.5vw,4.75rem);
   font-weight:700;
-  line-height:1.03;
-  letter-spacing:-.02em;
-  margin-bottom:1rem;
+  line-height:.97;
+  letter-spacing:-.025em;
+  margin-bottom:1.25rem;
   color:var(--ink);
-}
-h1 em,
-h1 a{
-  font-style:normal;
-  background:linear-gradient(135deg,var(--accent),var(--orange));
-  -webkit-background-clip:text;-webkit-text-fill-color:transparent;
-  background-clip:text;
-  color:transparent;
-}
-h1 a{
-  text-decoration:none;
-}
-h1 a:hover,
-h1 a:visited{
-  color:transparent;
-  -webkit-text-fill-color:transparent;
-}
-h1 a:focus-visible{
-  outline:2px solid var(--accent);
-  outline-offset:4px;
-  border-radius:4px;
+  text-wrap:balance;
 }
 
+/* Sunrise gradient — h1-start and h1-end differ significantly in both modes */
+h1 em,h1 a{
+  font-style:normal;
+  background:linear-gradient(130deg,var(--h1-start) 0%,var(--h1-end) 100%);
+  -webkit-background-clip:text;-webkit-text-fill-color:transparent;
+  background-clip:text;color:transparent;
+}
+
+/* Underline marks the link as interactive, distinct from the em */
+h1 a{
+  text-decoration:underline;
+  text-decoration-color:color-mix(in srgb,var(--h1-start) 40%,transparent);
+  text-decoration-thickness:2px;
+  text-underline-offset:5px;
+}
+h1 a:hover{text-decoration-color:var(--h1-start)}
+h1 a:hover,h1 a:visited{color:transparent;-webkit-text-fill-color:transparent}
+h1 a:focus-visible{outline:2px solid var(--accent);outline-offset:4px;border-radius:4px}
+
 .hero-sub{
-  font-size:1.1rem;line-height:1.6;
+  font-size:1.05rem;line-height:1.65;
   color:var(--ink-2);
-  max-width:52ch;margin:0 auto;
+  max-width:52ch;
   text-wrap:pretty;
 }
-.hero-sub + .hero-sub{
-  margin-top:.9rem;
+.hero-sub+.hero-sub{
+  margin-top:.85rem;
   margin-bottom:2rem;
 }
 
 .endpoint{
   display:inline-flex;align-items:center;gap:.5rem;
-  padding:.6rem 1rem;border-radius:var(--radius);
+  padding:.55rem .9rem;border-radius:var(--radius);
   background:var(--surface);border:1px solid var(--border);
-  font-family:var(--mono);font-size:.85rem;
+  font-family:var(--mono);font-size:.82rem;
   color:var(--ink);
-  transition:border-color .2s;
+  transition:border-color .2s,box-shadow .2s;
   max-width:100%;
 }
-.endpoint:hover{border-color:var(--border-2)}
+.endpoint:hover{border-color:var(--border-2);box-shadow:0 0 0 3px var(--accent-glow)}
 .endpoint code{overflow-wrap:anywhere;word-break:break-all}
 .endpoint-badge{
-  padding:.15rem .45rem;border-radius:4px;
-  font-size:.6rem;font-weight:700;letter-spacing:.04em;
+  padding:.15rem .4rem;border-radius:4px;
+  font-size:.58rem;font-weight:700;letter-spacing:.06em;
   background:var(--accent-glow);color:var(--accent);
   flex-shrink:0;
 }
 .hero-meta{
-  margin-top:1rem;
-  font-size:.76rem;
+  margin-top:1.1rem;
+  font-size:.74rem;
   color:var(--ink-3);
-  letter-spacing:.03em;
+  letter-spacing:.02em;
 }
 
+/* TERMINAL PREVIEW */
+.hero-terminal-wrap{
+  flex:0 0 360px;
+  width:360px;
+}
+.terminal{
+  background:var(--code-bg);
+  border:1px solid var(--border);
+  border-radius:10px;
+  overflow:hidden;
+  font-family:var(--mono);
+  font-size:.72rem;
+  line-height:1.5;
+  box-shadow:0 8px 40px rgba(0,0,0,.45),0 0 0 1px rgba(255,255,255,.04);
+}
+.terminal-bar{
+  background:var(--surface);
+  border-bottom:1px solid var(--border);
+  padding:.55rem .85rem;
+  display:flex;
+  align-items:center;
+  gap:.4rem;
+}
+.terminal-btn{width:9px;height:9px;border-radius:50%;flex-shrink:0}
+.terminal-btn-r{background:#e05e5e}
+.terminal-btn-y{background:#e0b450}
+.terminal-btn-g{background:#4ec864}
+.terminal-label{
+  margin-left:.5rem;
+  font-size:.62rem;
+  color:var(--ink-3);
+  letter-spacing:.05em;
+  flex:1;
+}
+.terminal-body{padding:1rem 1.2rem 1.2rem}
+.terminal-line{
+  color:var(--ink-3);
+  margin-bottom:.1rem;
+}
+.terminal-prompt{color:var(--accent);margin-right:.35rem;font-weight:700}
+.terminal-cmd{color:var(--ink)}
+.terminal-dim{color:var(--ink-4)}
+.terminal-success{color:var(--green);margin-right:.4rem}
+.terminal-blank{display:block;height:.55rem}
+.terminal-task{
+  display:flex;
+  align-items:baseline;
+  gap:.5rem;
+  margin-bottom:.22rem;
+  color:var(--ink-2);
+}
+.terminal-task-dot-active{color:var(--accent)}
+.terminal-task-dot-open{color:var(--ink-4)}
+.terminal-task-title{flex:1;min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.terminal-priority-high{color:var(--h1-end);font-size:.65rem;flex-shrink:0;letter-spacing:.04em}
+.terminal-priority-med{color:var(--ink-3);font-size:.65rem;flex-shrink:0;letter-spacing:.04em}
+.terminal-divider{border:none;border-top:1px solid var(--border);margin:.65rem 0}
+.terminal-count{color:var(--ink-4);font-size:.67rem}
+.terminal-cursor{
+  display:inline-block;
+  width:5px;height:.82em;
+  background:var(--accent);
+  vertical-align:text-bottom;
+  margin-left:2px;
+  animation:blink-cur 1.1s step-end infinite;
+}
+@keyframes blink-cur{0%,100%{opacity:1}50%{opacity:0}}
+
+/* PAGE SECTIONS */
 .page-section{
   max-width:960px;
   margin:0 auto;
   padding:3.5rem 2rem;
   scroll-margin-top:4.5rem;
 }
-.page-section + .page-section{border-top:1px solid var(--border)}
+.page-section+.page-section{border-top:1px solid var(--border)}
 
+/* Editorial section label with extending rule */
 .section-label{
-  font-size:.7rem;font-weight:700;
-  text-transform:uppercase;letter-spacing:.08em;
+  display:flex;
+  align-items:center;
+  gap:.85rem;
+  font-size:.67rem;font-weight:700;
+  text-transform:uppercase;letter-spacing:.1em;
   color:var(--ink-3);
-  margin-bottom:1.25rem;
+  margin-bottom:1.5rem;
+}
+.section-label::after{
+  content:'';
+  flex:1;
+  height:1px;
+  background:linear-gradient(to right,var(--border),transparent);
 }
 
+/* SETUP ITEMS */
 .setup-list{display:flex;flex-direction:column;gap:.75rem}
-
 .setup-item{
   padding:1rem 1.25rem;
   border-radius:var(--radius);
   border:1px solid var(--border);
   background:var(--surface);
-  transition:border-color .2s;
+  transition:border-color .2s,background .2s;
+  position:relative;
+  overflow:hidden;
 }
-.setup-item:hover{border-color:var(--border-2)}
+.setup-item::before{
+  content:'';
+  position:absolute;
+  left:0;top:0;bottom:0;
+  width:2px;
+  background:linear-gradient(to bottom,var(--h1-start),var(--h1-end));
+  opacity:0;
+  transition:opacity .2s;
+}
+.setup-item:hover{border-color:var(--border-2);background:var(--surface-2)}
+.setup-item:hover::before{opacity:1}
 
 .setup-header{
   display:flex;align-items:center;gap:.5rem;
   margin-bottom:.5rem;
 }
+.setup-step{
+  font-family:var(--mono);
+  font-size:.6rem;
+  font-weight:700;
+  color:var(--accent);
+  letter-spacing:.08em;
+  opacity:.8;
+}
 .setup-name{
-  font-size:.75rem;font-weight:700;
-  text-transform:uppercase;letter-spacing:.06em;
+  font-size:.72rem;font-weight:700;
+  text-transform:uppercase;letter-spacing:.07em;
   color:var(--ink-3);
 }
 .setup-desc{font-size:.8rem;color:var(--ink-3);margin-bottom:.4rem}
 
+/* CODE */
 pre{
-  margin:0;padding:.6rem .75rem;
+  margin:0;padding:.65rem .8rem;
   background:var(--code-bg);
   border:1px solid var(--border);
-  border-radius:8px;
-  font-size:.78rem;line-height:1.55;
+  border-radius:7px;
+  font-size:.76rem;line-height:1.55;
   white-space:pre-wrap;
   word-break:break-all;
   overflow-wrap:anywhere;
@@ -255,115 +382,109 @@ p code,li code{
   overflow-wrap:anywhere;word-break:break-word;
 }
 
+/* TOOLS */
 .tools-columns{
   display:grid;
   grid-template-columns:repeat(3,1fr);
   gap:1.5rem 2rem;
 }
 .tool-group h3{
-  font-size:.7rem;font-weight:700;
-  text-transform:uppercase;letter-spacing:.08em;
+  font-size:.65rem;font-weight:700;
+  text-transform:uppercase;letter-spacing:.09em;
   color:var(--ink-3);
-  margin-bottom:.6rem;
+  margin-bottom:.65rem;
   padding-bottom:.4rem;
   border-bottom:1px solid var(--border);
 }
 .tool-group--spaced{margin-top:1.25rem}
-
 .tool-list{list-style:none;padding:0}
 .tool-list li{
-  padding:.25rem 0;
-  font-size:.8rem;
-  display:flex;align-items:center;gap:.35rem;
+  padding:.22rem 0;
+  font-size:.78rem;
+  display:flex;align-items:flex-start;gap:.35rem;
   color:var(--ink-2);
 }
 .tool-list li code{
-  font-size:.78rem;
+  font-size:.76rem;
   background:none;border:none;padding:0;
   color:var(--ink);
 }
-
-.tool-dot{
-  width:5px;height:5px;border-radius:50%;
-  flex-shrink:0;
-}
+.tool-dot{width:5px;height:5px;border-radius:50%;flex-shrink:0;margin-top:.42em}
 .dot-green{background:var(--green)}
 .dot-blue{background:var(--blue)}
 .dot-orange{background:var(--orange)}
 
-.endpoint-table{
-  width:100%;
-  border-collapse:collapse;
-  font-size:.8rem;
-}
+/* ENDPOINT TABLE */
+.endpoint-table{width:100%;border-collapse:collapse;font-size:.78rem}
 .endpoint-table th{
   text-align:left;
-  font-size:.65rem;font-weight:700;
-  text-transform:uppercase;letter-spacing:.06em;
+  font-size:.63rem;font-weight:700;
+  text-transform:uppercase;letter-spacing:.07em;
   color:var(--ink-4);
   padding:.4rem 0;
   border-bottom:1px solid var(--border);
 }
 .endpoint-table td{
-  padding:.45rem 0;
+  padding:.42rem 0;
   border-bottom:1px solid var(--border);
   color:var(--ink-2);
 }
 .endpoint-table tr:last-child td{border-bottom:none}
-.endpoint-table code{font-size:.78rem;color:var(--ink)}
-
+.endpoint-table code{font-size:.76rem;color:var(--ink)}
 .method-badge{
-  display:inline-block;padding:.1rem .4rem;border-radius:4px;
-  font-family:var(--mono);font-size:.65rem;font-weight:700;
+  display:inline-block;padding:.1rem .38rem;border-radius:4px;
+  font-family:var(--mono);font-size:.62rem;font-weight:700;
   letter-spacing:.03em;
 }
 .badge-post{background:var(--blue-dim);color:var(--blue)}
 .badge-get{background:var(--green-dim);color:var(--green)}
 
+/* ROADMAP */
 .roadmap{
   list-style:none;padding:0;
   margin-top:1rem;
   display:flex;flex-wrap:wrap;gap:.4rem;
 }
 .roadmap li{
-  padding:.3rem .65rem;border-radius:999px;
-  font-size:.72rem;
+  padding:.28rem .6rem;border-radius:999px;
+  font-size:.7rem;
   border:1px dashed var(--border-2);
   color:var(--ink-3);
+  transition:border-color .2s,color .2s;
 }
+.roadmap li:hover{border-color:var(--accent);color:var(--ink-2)}
 
+/* FOOTER */
 footer{
   border-top:1px solid var(--border);
-  padding:1.25rem 2rem;
+  padding:1.5rem 2rem;
   display:flex;align-items:center;justify-content:space-between;
   max-width:960px;
   margin:0 auto;
-  font-size:.78rem;color:var(--ink-4);
+  font-size:.76rem;color:var(--ink-4);
 }
 footer a{
   color:var(--ink-3);text-decoration:none;
   display:inline-flex;align-items:center;gap:.35rem;
   transition:color .15s;
 }
-.footer-links{
-  display:flex;
-  align-items:center;
-  gap:.85rem;
-  flex-wrap:wrap;
-}
+.footer-links{display:flex;align-items:center;gap:.85rem;flex-wrap:wrap}
 footer a:hover{color:var(--ink)}
 footer a:focus-visible{outline:2px solid var(--accent);outline-offset:2px;border-radius:3px}
 footer svg{width:14px;height:14px}
 
+/* GLOBAL LINKS */
 a{color:var(--accent);text-decoration:none;transition:color .15s;touch-action:manipulation}
 a:hover{color:var(--ink)}
 a:focus-visible{outline:2px solid var(--accent);outline-offset:3px;border-radius:3px}
 
+/* ANIMATIONS */
 @keyframes fadeUp{
-  from{opacity:0;transform:translateY(8px)}
+  from{opacity:0;transform:translateY(10px)}
   to{opacity:1;transform:translateY(0)}
 }
-.hero{animation:fadeUp .6s ease both}
+.hero-content{animation:fadeUp .7s cubic-bezier(.16,1,.3,1) both}
+.hero-terminal-wrap{animation:fadeUp .7s cubic-bezier(.16,1,.3,1) both;animation-delay:.15s}
 .page-section{animation:fadeUp .6s ease both;animation-delay:.1s}
 .page-section:nth-child(3){animation-delay:.15s}
 .page-section:nth-child(4){animation-delay:.2s}
@@ -377,15 +498,25 @@ a:focus-visible{outline:2px solid var(--accent);outline-offset:3px;border-radius
   }
 }
 
+/* RESPONSIVE */
+@media(max-width:900px){
+  .hero{gap:2rem}
+  .hero-terminal-wrap{flex:0 0 300px;width:300px}
+  .terminal{font-size:.68rem}
+}
 @media(max-width:768px){
+  .hero{flex-direction:column;text-align:center}
+  .hero-content{text-align:center}
+  .hero-sub{max-width:none}
+  .hero-terminal-wrap{width:100%;max-width:440px;flex:none}
   .tools-columns{grid-template-columns:1fr}
 }
-
 @media(max-width:640px){
   nav{padding:.6rem 1rem}
   .hero{padding:3rem 1.25rem 2.5rem}
   .page-section{padding:2.5rem 1.25rem}
-  footer{padding:1rem 1.25rem;flex-direction:column;gap:.5rem}
+  footer{padding:1rem 1.25rem;flex-direction:column;gap:.5rem;text-align:center}
   .nav-links{gap:.75rem}
+  .hero-terminal-wrap{display:none}
 }
 `;


### PR DESCRIPTION
## Summary

- **Split hero layout** — text left, terminal preview right showing a live MCP session (stacks on tablet, hidden on mobile)
- **New color system** — warm near-black background with `--h1-start`/`--h1-end` CSS variables that differ significantly per mode: gold → orange in dark, rust → deep ocean in light; gradient is unmistakably visible in both
- **Link fix** — `h1 a` now has an explicit `text-decoration-color` underline so "TickTick" reads as a hyperlink, distinct from the `<em>` gradient text
- **Editorial details** — grain texture overlay, extending section-label rules, step numbers on setup items, spring-curve entrance animations, accent left-border on setup item hover
- **Tool list cleanup** — removed long annotations from task tool labels that were wrapping mid-word; dot bullet alignment fixed to `flex-start` for wrapped lines

## Test plan

- [ ] Check dark mode — gold→orange h1 gradient visible, terminal panel renders
- [ ] Check light mode — rust→ocean gradient clearly distinct, no flat/muddy colours
- [ ] Verify `h1 a` ("TickTick") shows underline and is visually distinct from `<em>` text
- [ ] Resize to tablet (768px) — hero stacks, terminal panel below text
- [ ] Resize to mobile (640px) — terminal panel hidden, layout clean
- [ ] Run `npm run build:homepage` and confirm no errors